### PR TITLE
update pubspec dependencies & add build runner

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,16 +2,12 @@ name: comiko_backend
 description: Comiko backend project.
 version: 0.0.1
 
-environment:
-  sdk: '>=1.24.0 <2.0.0'
-
-dependencies:
-  comiko_shared:
-    git: https://github.com/comiko-app/shared.git
-
-dependency_overrides:
-  comiko_shared:
-    path: ../shared
-
 dev_dependencies:
-  test: ^0.12.0
+  build_runner: "^0.10.1+1"
+  build_test: "0.10.3+1"
+  test: "^1.3.0"
+
+  comiko_shared:
+    path: "../shared"
+
+


### PR DESCRIPTION
Update dependencies to fit SDK 2.1.0+

Take note that flutter test/build is no longer a valid tool
❯ pub run build_runner test